### PR TITLE
Fixing "sudo: nix: command not found" when upgrading nix

### DIFF
--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -11,7 +11,7 @@ We at [Determinate Systems][detsys] recommend using Nix **2.18.1** or newer in c
 You can upgrade Nix using the [`upgrade-nix`][upgrade-nix] command. To upgrade to Nix 2.18.1:
 
 ```shell
-sudo nix upgrade-nix \
+sudo -E env "PATH=$PATH" nix upgrade-nix \
   --nix-store-paths-url https://releases.nixos.org/nix/nix-2.18.1/fallback-paths.nix
 ```
 


### PR DESCRIPTION
I installed nix 2.15 on Ubuntu 22.04 using DeterminateSystems installer. When trying to upgrade nix I got "sudo: nix: command not found". This workaround allowed me to successfully upgrade nix - it is using environment of normal user when running command as root user.