### PR TITLE
Fix typo in snippet on 'Flake schemas' page

### DIFF
--- a/pages/concepts/flake-schemas.mdx
+++ b/pages/concepts/flake-schemas.mdx
@@ -25,7 +25,7 @@ Then add a `schemas` output:
 
 ```nix filename="flake.nix"
 {
-  outputs = { flake-schemas, .. }: {
+  outputs = { flake-schemas, ... }: {
     inherit (flake-schemas) schemas;
 
     # other outputs


### PR DESCRIPTION
Fixes a trivial typo on the 'Flake schemas' page (missing period in the ellipsis).

Feel free to discard and include this fix as part of a future content update.